### PR TITLE
Make keyword lookup case insensitive

### DIFF
--- a/get_wikipedia.py
+++ b/get_wikipedia.py
@@ -26,9 +26,10 @@ class WikipediaDocument(Document):
     def lookup(self, keyword):
         # Search for the keyword in the text
         text = self.text
-        index = text.find(keyword)
-        if index == -1:  # Keyword not found
+        match = re.search(keyword, text, re.IGNORECASE)
+        if match is None:  # Keyword not found
             return None
+        index = match.span()[0]
 
         # Determine the start and end points for the extraction
         start = max(index - self.chunk_size // 1, 0)


### PR DESCRIPTION
Occasionally LLM would perform lookups with invalid casing – e.g. "personal life" instead of "Personal life".