### PR TITLE
Add a PromptBuilder, providing an abstraction for building (OpenAI or…

### DIFF
--- a/react.py
+++ b/react.py
@@ -5,7 +5,7 @@ import time
 
 import get_wikipedia
 from get_wikipedia import WikipediaApi, ContentRecord
-from reactors import FunctionalReactor, TextualReactor
+from reactors import FunctionalReactor, TextualReactor, PromptFormat
 
 def openai_query(messages, functions=None):
     def convert_to_dict(obj):
@@ -20,6 +20,9 @@ def openai_query(messages, functions=None):
     if functions is not None:
         args["functions"] = functions
         args["function_call"] = "auto"
+
+    if type(messages) == str:
+        messages = [{ "role": "user", "content": messages }]
 
     response = openai.ChatCompletion.create(
         model="gpt-3.5-turbo-0613",
@@ -100,11 +103,11 @@ if __name__ == "__main__":
     # question = "how many keys does a US-ANSI keyboard have on it?"
     question = "How many children does Donald Tusk have?"
 
-    mode = 'compare'
+    mode = 'functional'
 
     reactors = []
     if mode == 'textual' or mode == 'compare':
-        reactors.append(TextualReactor(openai_query))
+        reactors.append(TextualReactor(openai_query, PromptFormat.plain))
     if mode == 'functional' or mode == 'compare':
         reactors.append(FunctionalReactor(openai_query))
 

--- a/reactors/__init__.py
+++ b/reactors/__init__.py
@@ -1,2 +1,3 @@
 from .textual import TextualReactor
 from .functional import FunctionalReactor
+from .prompt_builder import OutputFormat as PromptFormat

--- a/reactors/functional.py
+++ b/reactors/functional.py
@@ -1,6 +1,7 @@
 import json
 
 from .common import Action
+from .prompt_builder import *
 
 system_message = '''
 Solve a question answering task with interleaving Thought, Action, Observation steps. 
@@ -16,152 +17,121 @@ After each function call, please analyze the response reflect on it and decide w
 '''
 
 examples = [
-    { 'content': 'Question: What is the elevation range for the area that the eastern sector of the Colorado orogeny extends into?',
-    'role': 'user'},
-    { 'function_call': {
-            'arguments': json.dumps({
-                "thought": 'Thought: I need to search Colorado orogeny, find the area that the eastern sector of the Colorado orogeny extends into, then find the elevation range of the area.',
-                "query": "Colorado orogeny"
-             }),
-            'name': 'search'},
-      "content": 'I need to call a "search" function',
-      'role': 'assistant'},
-    { 'content': "Observations:\n"
-                 "Wikipedia search results for query: 'Colorado orogeny' is: 'Colorado orogeny', 'Laramide orogeny', "
-                 "'Colorado Mineral Belt', 'Sevier orogeny', 'Geology of Colorado', 'Wyoming Craton', 'Timeline of "
-                 "natural history', 'Variscan orogeny', 'Sangre de Cristo Range', 'Colorado Plateau'\n"
-                 "Successfully retrieved 'Colorado orogeny' from Wikipedia.\n"
-                 'The retrieved wikipedia page summary starts with: The Colorado orogeny was an episode of mountain '
-                 'building (an orogeny) in Colorado and surrounding areas.This took place from 1780 to 1650 million '
-                 'years ago (Mya), during the Paleoproterozoic (Statherian Period). It is recorded in the Colorado '
-                 'orogen, a >500-km-wide belt of oceanic arc rock that extends southward into New Mexico. The Colorado '
-                 'orogeny was likely part of the larger Yavapai orogeny.\n',
-      'name': 'search',
-      'role': 'function'},
-    { 'function_call': {
-            'arguments': json.dumps({
-                "thought": "Thought: It does not mention the eastern sector of the Colorado orogeny. I need to look up eastern sector.",
-                "keyword": "eastern sector"
-            }),
-            'name': 'lookup'
-        },
-      "content": 'I need to call a "lookup" function',
-      'role': 'assistant'},
-    { "role": "user",
-      "content": "Observations: == Description == The Colorado orogen, formerly called the Colorado province, is a >500-km-wide belt of oceanic arc rock (1.78–1.65 Ga) that extends southward into New Mexico and composes a major part of the Proterozoic provinces of southwestern United States. This transcontinental collisional event occurred during the Paleoproterozoic (Statherian Period). The Wyoming sector of the Colorado orogeny was formerly called the Medicine Bow orogeny. The eastern sector extends into the High Plains and is called the Central Plains orogeny. The boundary between the Colorado orogeny and the Wyoming craton is the Cheyenne belt, a 5-km-wide mylonitic shear zone that verges northward. The Cheyenne belt transects and cuts off the south edge of the older Trans-Hudson orogeny." },
-    { 'function_call': {
-            'arguments': json.dumps({
-                "thought": "Thought: The eastern sector of Colorado orogeny extends into the High Plains, so High Plains is the area. I need to search High Plains and find its elevation range.",
-                "query": "High Plains"
-            }),
-            'name': 'search'
-        },
-      "content": 'I need to call a "search" function',
-      'role': 'assistant'},
-    { 'content': "Observations:\n"
-               "Wikipedia search results for query: 'High Plains' is: 'High Plains Drifter', 'High Plains', 'High "
-               "Plains (United States)', 'Ogallala Aquifer', 'Great Plains', 'High Plains (Australia)', 'High Plains "
-               "Reader', 'High Plains Invaders', 'Bogong High Plains', 'Llano Estacado'\n"
-               "Successfully retrieved 'High Plains Drifter' from Wikipedia.\n"
-               'The retrieved wikipedia page summary starts with: High Plains Drifter is a 1973 American Western film '
-               'directed by Clint Eastwood, written by Ernest Tidyman, and produced by Robert Daley for The Malpaso '
-               'Company and Universal Pictures.The film stars Eastwood as a mysterious stranger who metes out justice '
-               "in a corrupt frontier mining town. The film was influenced by the work of Eastwood's two major "
-               'collaborators, film directors Sergio Leone and Don Siegel. In addition to Eastwood, the film also '
-               'co-stars Verna Bloom, Mariana Hill, Mitchell Ryan, Jack Ging, and Stefan Gierasch. The film was shot '
-               'on location on the shores of Mono Lake, California. Dee Barton wrote the film score. The film was '
-               'critically acclaimed at the time of its initial release and remains popular.\n',
-    'name': 'search',
-    'role': 'function'},
-   { 'function_call': {
-        'arguments': json.dumps({
-            "thought": 'Tought: High Plains Drifter is a film. I need information about different High Plains',
-            "query": "High Plains elevation range"
-        }),
-        'name': 'search'},
-     "content": 'I need to call a "search" function',
-     'role': 'assistant'},
-   { 'content': "Observations:\n"
-               "Wikipedia search results for query: 'High Plains elevation range' is: 'High Plains (United States)', "
-               "'Laramie Plains', 'Plain', 'Roaring Plains West Wilderness', 'Northern Basin and Range ecoregion', "
-               "'Great Basin Desert', 'List of elevation extremes by country', 'Liverpool Plains', 'Plateau', "
-               "'Geography of the United States'\n"
-               "Successfully retrieved 'High Plains (United States)' from Wikipedia.\n"
-               'The retrieved wikipedia page summary starts with: The High Plains are a subregion of the Great Plains, '
-               'mainly in the Western United States, but also partly in the Midwest states of Nebraska, Kansas, and '
-               'South Dakota, generally encompassing the western part of the Great Plains before the region reaches '
-               'the Rocky Mountains.The High Plains are located in eastern Montana, southeastern Wyoming, southwestern '
-               'South Dakota, western Nebraska, eastern Colorado, western Kansas, eastern New Mexico, the Oklahoma '
-               'Panhandle, and the Texas Panhandle. The southern region of the Western High Plains ecology region '
-               'contains the geological formation known as Llano Estacado which can be seen from a short distance or '
-               'on satellite maps. From east to west, the High Plains rise in elevation from around 1,800 to 7,000 ft '
-               '(550 to 2,130 m).\n',
-    'name': 'search',
-    'role': 'function'},
-  { 'content': 'Thought: The High Plains have an elevation range from around 1,800 to 7,000 feet. I can use this '
-               'information to answer the question about the elevation range of the area that the eastern sector of '
-               'the Colorado orogeny extends into.',
-    'function_call': {
-        'arguments': json.dumps({
-            "answer": "The elevation range for the area that the eastern sector of the Colorado orogeny extends into is approximately 1,800 to 7,000 feet."
-        }),
-        'name': 'finish'
-    },
-    "content": 'I need to call a "finish" function',
-    'role': 'assistant'},
+    User("Question: What is the elevation range for the area that the eastern sector of the Colorado orogeny extends into?"),
+    FunctionCall(
+        "search",
+        thought='I need to search Colorado orogeny, find the area that the eastern sector of the Colorado orogeny extends into, then find the elevation range of the area.',
+        query="Colorado orogeny",
+    ),
+    FunctionResult(
+        'search',
+        "Wikipedia search results for query: 'Colorado orogeny' is: 'Colorado orogeny', 'Laramide orogeny', "
+        "'Colorado Mineral Belt', 'Sevier orogeny', 'Geology of Colorado', 'Wyoming Craton', 'Timeline of "
+        "natural history', 'Variscan orogeny', 'Sangre de Cristo Range', 'Colorado Plateau'\n"
+        "Successfully retrieved 'Colorado orogeny' from Wikipedia.\n"
+        'The retrieved wikipedia page summary starts with: The Colorado orogeny was an episode of mountain '
+        'building (an orogeny) in Colorado and surrounding areas.This took place from 1780 to 1650 million '
+        'years ago (Mya), during the Paleoproterozoic (Statherian Period). It is recorded in the Colorado '
+        'orogen, a >500-km-wide belt of oceanic arc rock that extends southward into New Mexico. The Colorado '
+        'orogeny was likely part of the larger Yavapai orogeny.\n',
+    ),
+    FunctionCall(
+        'lookup',
+        thought="It does not mention the eastern sector of the Colorado orogeny. I need to look up eastern sector.",
+        keyword="eastern sector",
+    ),
+    FunctionResult(
+        'lookup',
+        "== Description == The Colorado orogen, formerly called the Colorado province, is a >500-km-wide belt of oceanic arc rock (1.78–1.65 Ga) that extends southward into New Mexico and composes a major part of the Proterozoic provinces of southwestern United States. This transcontinental collisional event occurred during the Paleoproterozoic (Statherian Period). The Wyoming sector of the Colorado orogeny was formerly called the Medicine Bow orogeny. The eastern sector extends into the High Plains and is called the Central Plains orogeny. The boundary between the Colorado orogeny and the Wyoming craton is the Cheyenne belt, a 5-km-wide mylonitic shear zone that verges northward. The Cheyenne belt transects and cuts off the south edge of the older Trans-Hudson orogeny."
+    ),
+    FunctionCall(
+        'search',
+        thought="The eastern sector of Colorado orogeny extends into the High Plains, so High Plains is the area. I need to search High Plains and find its elevation range.",
+        query="High Plains",
+    ),
+    FunctionResult(
+        'search',
+        "Wikipedia search results for query: 'High Plains' is: 'High Plains Drifter', 'High Plains', 'High "
+        "Plains (United States)', 'Ogallala Aquifer', 'Great Plains', 'High Plains (Australia)', 'High Plains "
+        "Reader', 'High Plains Invaders', 'Bogong High Plains', 'Llano Estacado'\n"
+        "Successfully retrieved 'High Plains Drifter' from Wikipedia.\n"
+        'The retrieved wikipedia page summary starts with: High Plains Drifter is a 1973 American Western film '
+        'directed by Clint Eastwood, written by Ernest Tidyman, and produced by Robert Daley for The Malpaso '
+        'Company and Universal Pictures.The film stars Eastwood as a mysterious stranger who metes out justice '
+        "in a corrupt frontier mining town. The film was influenced by the work of Eastwood's two major "
+        'collaborators, film directors Sergio Leone and Don Siegel. In addition to Eastwood, the film also '
+        'co-stars Verna Bloom, Mariana Hill, Mitchell Ryan, Jack Ging, and Stefan Gierasch. The film was shot '
+        'on location on the shores of Mono Lake, California. Dee Barton wrote the film score. The film was '
+        'critically acclaimed at the time of its initial release and remains popular.\n',
+    ),
+    FunctionCall(
+        'search',
+        thought='High Plains Drifter is a film. I need information about different High Plains',
+        query="High Plains elevation range",
+    ),
+    FunctionResult(
+        'search',
+        "Wikipedia search results for query: 'High Plains elevation range' is: 'High Plains (United States)', "
+        "'Laramie Plains', 'Plain', 'Roaring Plains West Wilderness', 'Northern Basin and Range ecoregion', "
+        "'Great Basin Desert', 'List of elevation extremes by country', 'Liverpool Plains', 'Plateau', "
+        "'Geography of the United States'\n"
+        "Successfully retrieved 'High Plains (United States)' from Wikipedia.\n"
+        'The retrieved wikipedia page summary starts with: The High Plains are a subregion of the Great Plains, '
+        'mainly in the Western United States, but also partly in the Midwest states of Nebraska, Kansas, and '
+        'South Dakota, generally encompassing the western part of the Great Plains before the region reaches '
+        'the Rocky Mountains.The High Plains are located in eastern Montana, southeastern Wyoming, southwestern '
+        'South Dakota, western Nebraska, eastern Colorado, western Kansas, eastern New Mexico, the Oklahoma '
+        'Panhandle, and the Texas Panhandle. The southern region of the Western High Plains ecology region '
+        'contains the geological formation known as Llano Estacado which can be seen from a short distance or '
+        'on satellite maps. From east to west, the High Plains rise in elevation from around 1,800 to 7,000 ft '
+        '(550 to 2,130 m).\n',
+    ),
+    FunctionCall(
+        'finish',
+        thought='The High Plains have an elevation range from around 1,800 to 7,000 feet. I can use this '
+        'information to answer the question about the elevation range of the area that the eastern sector of '
+        'the Colorado orogeny extends into.',
+        answer="The elevation range for the area that the eastern sector of the Colorado orogeny extends into is approximately 1,800 to 7,000 feet.",
+    ),
 
-    { 'content': 'Question: Musician and satirist Allie Goertz wrote a song about the "The Simpsons" character Milhouse, '
-               'who Matt Groening named after who?',
-      'role': 'user'},
-    { 'function_call': {
-            'arguments': json.dumps({
-                "thought": 'Thought: I need to find out who Matt Groening named the Simpsons character Milhouse after.',
-                "query": "Milhouse Simpson"
-            }),
-            'name': 'search'
-        },
-      "content": 'I need to call a "search" function',
-      'role': 'assistant'},
-    { 'content': "Observations:\n"
-               "Wikipedia search results for query: 'Milhouse Simpson' is: 'Milhouse Van Houten', 'A Milhouse "
-               "Divided', 'Bart Simpson', 'The Simpsons', 'List of recurring The Simpsons characters', 'Radioactive "
-               "Man (The Simpsons episode)', 'Milhouse of Sand and Fog', 'Treehouse of Horror XIX', 'The Simpsons "
-               "(season 35)', 'Homer Simpson'\n"
-               "Successfully retrieved 'Milhouse Van Houten' from Wikipedia.\n"
-               'The retrieved wikipedia page summary starts with: Milhouse Mussolini Van Houten is a recurring character '
-               'in the Fox animated television series The Simpsons voiced by Pamela Hayden and created by Matt '
-               "Groening.Milhouse is Bart Simpson's best friend in Mrs. Krabappel's fourth grade class at Springfield "
-               'Elementary School. He is insecure, gullible, and is often led into trouble by Bart, who takes '
-               "advantage of his friend's naïveté. Milhouse is a regular target for school bully Nelson Muntz and his "
-               "friends Jimbo Jones, Dolph Starbeam and Kearney Zzyzwicz. He has an unrequited crush on Bart's sister, "
-               'Lisa, which is a common plot element. Milhouse debuted in the 1988 commercial "The Butterfinger Group" '
-               'while The Simpsons was still airing as a cartoon short series on the Fox variety show The Tracey '
-               'Ullman Show. When The Simpsons was greenlit for a full series by Fox, Milhouse became one of the '
-               "series' most prominent recurring characters.\n",
-      'name': 'search',
-      'role': 'function'
-    },
-    { "role": "assistant",
-      'function_call': {
-          'arguments': json.dumps({
-              "thought": 'Thought: The summary does not tell who Milhouse is named after, I should check the section called "Creation".',
-              "keyword": "Creation"
-          }),
-          'name': 'lookup'
-      },
-      "content": 'I need to call a "lookup" function',
-    },
-    { "content": "Observations:\n Milhouse was named after U.S. president Richard Nixon, whose middle name was Milhous.",
-      'name': 'lookup',
-      'role': 'function'},
-    { "role": "assistant",
-      "content": 'Thought: Milhouse was named after U.S. president Richard Nixon, so the answer is President Richard Nixon.',
-      'function_call': {
-          'arguments': json.dumps({ "answer": "President Richard Nixon" }),
-          'name': 'finish'
-       },
-      "content": 'I need to call a "finish" function',
-    },
+    User('Question: Musician and satirist Allie Goertz wrote a song about the "The Simpsons" character Milhouse, who Matt Groening named after who?'),
+    FunctionCall(
+        'search',
+        thought='I need to find out who Matt Groening named the Simpsons character Milhouse after.',
+        query="Milhouse Simpson",
+    ),
+    FunctionResult(
+        'search',
+        "Wikipedia search results for query: 'Milhouse Simpson' is: 'Milhouse Van Houten', 'A Milhouse "
+        "Divided', 'Bart Simpson', 'The Simpsons', 'List of recurring The Simpsons characters', 'Radioactive "
+        "Man (The Simpsons episode)', 'Milhouse of Sand and Fog', 'Treehouse of Horror XIX', 'The Simpsons "
+        "(season 35)', 'Homer Simpson'\n"
+        "Successfully retrieved 'Milhouse Van Houten' from Wikipedia.\n"
+        'The retrieved wikipedia page summary starts with: Milhouse Mussolini Van Houten is a recurring character '
+        'in the Fox animated television series The Simpsons voiced by Pamela Hayden and created by Matt '
+        "Groening.Milhouse is Bart Simpson's best friend in Mrs. Krabappel's fourth grade class at Springfield "
+        'Elementary School. He is insecure, gullible, and is often led into trouble by Bart, who takes '
+        "advantage of his friend's naïveté. Milhouse is a regular target for school bully Nelson Muntz and his "
+        "friends Jimbo Jones, Dolph Starbeam and Kearney Zzyzwicz. He has an unrequited crush on Bart's sister, "
+        'Lisa, which is a common plot element. Milhouse debuted in the 1988 commercial "The Butterfinger Group" '
+        'while The Simpsons was still airing as a cartoon short series on the Fox variety show The Tracey '
+        'Ullman Show. When The Simpsons was greenlit for a full series by Fox, Milhouse became one of the '
+        "series' most prominent recurring characters.\n",
+    ),
+    FunctionCall(
+        'lookup',
+        thought='The summary does not tell who Milhouse is named after, I should check the section called "Creation".',
+        keyword="Creation",
+    ),
+    FunctionResult(
+        'lookup',
+        "Milhouse was named after U.S. president Richard Nixon, whose middle name was Milhouse.",
+    ),
+    FunctionCall(
+        'finish',
+        thought="Milhouse was named after U.S. president Richard Nixon, so the answer is President Richard Nixon.",
+        answer="President Richard Nixon",
+    ),
 ]
 
 functions = [
@@ -210,6 +180,10 @@ functions = [
                 "answer": {
                     "type": "string",
                     "description": "The answer to the user's question",
+                },
+                "thought": {
+                    "type": "string",
+                    "description": "The explanation for why this answer was chosen",
                 }
             },
             "required": ["answer"],
@@ -219,18 +193,21 @@ functions = [
 
 class FunctionalReactor:
     def __init__(self, query_function):
-        self.messages = [{"role": "system", "content": system_message}] + examples
+        self.prompt = PromptBuilder([
+            System(system_message),
+            *examples
+        ])
         self.query_function = query_function
 
     def add_question(self, question: str):
-        self.messages.append({ "role": "user", "content": f"Question: {question}" }) 
+        self.prompt.push(User(f"Question: {question}")) 
 
     def add_observation(self, observation, action: Action):
-        self.messages.append({ "role": "function", "name": action.name, "content": "observation" })
+        self.prompt.push(FunctionResult(action.name, observation))
 
     def query(self) -> Action:
-        response = self.query_function(self.messages, functions)
-        self.messages.append(response)
+        response = self.query_function(self.prompt.build(OutputFormat.openai_messages), functions)
+        self.prompt.push(OpenAIMessage(response))
         print("<<<", response)
 
         if response.get("function_call"):

--- a/reactors/prompt_builder.py
+++ b/reactors/prompt_builder.py
@@ -1,0 +1,131 @@
+import json
+from typing import Any, Callable, Iterable
+
+class PromptMessage:
+    def plaintext(self) -> str:
+        raise Exception("plaintext() not implemented for", self.__class__.__name__)
+
+    def openai_message(self) -> dict:
+        raise Exception("openai_message() not implemented for", self.__class__.__name__)
+
+class System(PromptMessage):
+    def __init__(self, content: str):
+        self.content = content
+
+    def plaintext(self) -> str:
+        return self.content
+
+    def openai_message(self) -> dict:
+        return { "role": "system", "content": self.content }
+
+class User(PromptMessage):
+    def __init__(self, content: str):
+        self.content = content
+
+    def plaintext(self) -> str:
+        return self.content
+
+    def openai_message(self) -> dict:
+        return { "role": "user", "content": self.content }
+
+class Assistant(PromptMessage):
+    def __init__(self, content: str):
+        self.content = content
+
+    def plaintext(self) -> str:
+        return self.content
+
+    def openai_message(self) -> dict:
+        return { "role": "assistant", "content": self.content }
+
+class FunctionCall(PromptMessage):
+    def __init__(self, name: str, thought=None, **args):
+        self.name = name
+        self.thought = thought
+        self.args = args
+
+    def plaintext(self) -> str:
+        arguments = ", ".join(self.args.values())
+        thought = f"Thought: {self.thought}\n" if self.thought else ""
+        return f"{thought}{self.name}[{arguments}]"
+
+    def openai_message(self) -> dict:
+        arguments = dict(self.args)
+        if self.thought is not None:
+            arguments["thought"] = self.thought
+        return {
+            "role": "assistant",
+            "content": self.plaintext(),
+            "function_call": {
+                "name": self.name,
+                "arguments": json.dumps(arguments),
+            },
+        }
+
+class FunctionResult(PromptMessage):
+    def __init__(self, name: str, content: str):
+        self.name = name
+        self.content = content
+
+    def plaintext(self) -> str:
+        return f"Observation: {self.content}"
+
+    def openai_message(self) -> dict:
+        return {
+            "role": "function",
+            "name": self.name,
+            "content": self.content,
+        }
+
+class OpenAIMessage(PromptMessage):
+    def __init__(self, message: dict):
+        self.message = message
+
+    def plaintext(self) -> str:
+        return self.message.get("content", "")
+
+    def openai_message(self) -> dict:
+        return self.message
+
+Formatter = Callable[[Iterable[PromptMessage]], Any]
+
+class OutputFormat:
+    @staticmethod
+    def plain(messages: Iterable[PromptMessage]) -> str:
+        return "\n".join(map(lambda m: m.plaintext(), messages))
+
+    @staticmethod
+    def openai_messages(messages: Iterable[PromptMessage]) -> Iterable[dict]:
+        """ For OpenAI's `messages` API, which expects a list of JSON objects, we return an iterable of dicts """
+        return list(map(lambda m: m.openai_message(), messages))
+
+class PromptBuilder:
+    def __init__(self, parts: Iterable[PromptMessage]):
+        self.parts = list(parts)
+
+    def push(self, message: PromptMessage):
+        self.parts.append(message)
+
+    def build(self, method: Formatter) -> Any: # TODO return something more specific? Something openai_query can be sure to handle
+        return method(self.parts)
+
+
+if __name__ == "__main__":
+    assert Assistant("Thought: I need to search through my book of Monty Python jokes.\nSearch[Monty Python]").plaintext() \
+        == FunctionCall('Search', query="Monty Python", thought="I need to search through my book of Monty Python jokes.").plaintext()
+
+
+    from pprint import pprint
+
+    prompt = PromptBuilder([
+        System("Solve a question answering task with interleaving Thought, Action and Observation steps."),
+        User("Question: What is the terminal velocity of an unleaded swallow?"),
+        FunctionCall('Search', query="Monty Python", thought="I need to search through my book of Monty Python jokes."),
+        FunctionResult('Search', "Here are all the Monty Python jokes you know: ..."),
+        Assistant("Lookup[Unleaded swallow]"),
+        User("Observation: Did you mean Unladen Swallow?"),
+        Assistant("Finish[Oh you!]"),
+    ])
+
+    pprint(prompt.build(OutputFormat.plain))
+    # pprint(prompt.build(OutputFormat.openai_messages))

--- a/reactors/textual.py
+++ b/reactors/textual.py
@@ -1,4 +1,5 @@
 from .common import Action
+from .prompt_builder import *
 
 system_prompt = '''
 Solve a question answering task with interleaving Thought, Action, Observation steps. Thought can reason about the current situation, and Action can be three types:
@@ -9,73 +10,70 @@ Each of your answers must contain an Action, and may contain multiple Thoughts. 
 '''
 
 prompt_messages = [
-    { "role": "system",    "content": system_prompt },
-    { "role": "user",      "content": "Question: What is the elevation range for the area that the eastern sector of the Colorado orogeny extends into?" },
-    { "role": "assistant", "content": """Thought: I need to search Colorado orogeny, find the area that the eastern sector of the Colorado orogeny extends into, then find the elevation range of the area.
-Action: Search[Colorado orogeny]""" },
-    { "role": "user",      "content": """Observation: Wikipedia search results for query: 'Colorado orogeny' is: 'Colorado orogeny', 'Laramide orogeny', 'Sevier orogeny', 'Colorado Mineral Belt', 'Variscan orogeny', 'Wyoming Craton', 'Timeline of natural history', 'Antler orogeny', 'Denver Basin', 'Sangre de Cristo Range'
+    System(system_prompt),
+    User("Question: What is the elevation range for the area that the eastern sector of the Colorado orogeny extends into?"),
+    Assistant(
+"""Thought: I need to search Colorado orogeny, find the area that the eastern sector of the Colorado orogeny extends into, then find the elevation range of the area.
+Action: Search[Colorado orogeny]"""
+    ),
+    User("""
+Observation: Wikipedia search results for query: 'Colorado orogeny' is: 'Colorado orogeny', 'Laramide orogeny', 'Sevier orogeny', 'Colorado Mineral Belt', 'Variscan orogeny', 'Wyoming Craton', 'Timeline of natural history', 'Antler orogeny', 'Denver Basin', 'Sangre de Cristo Range'
 Observation: Successfully retrieved 'Colorado orogeny' from Wikipedia.
-Observation: the retrieved wikipedia page summary contains: The Colorado orogeny was an episode of mountain building (an orogeny) in Colorado and surrounding areas.This took place from 1780 to 1650 million years ago (Mya), during the Paleoproterozoic (Statherian Period). It is recorded in the Colorado orogen, a >500-km-wide belt of oceanic arc rock that extends southward into New Mexico. The Colorado orogeny was likely part of the larger Yavapai orogeny.""" },
-    { "role": "assistant", "content": """
-Thought: It does not mention the eastern sector of the Colorado orogeny. I need to look up eastern sector.
-Action: Lookup[eastern sector]
-""" },
-    { "role": "user",      "content": """
-Observation: == Description == The Colorado orogen, formerly called the Colorado province, is a >500-km-wide belt of oceanic arc rock (1.78–1.65 Ga) that extends southward into New Mexico and composes a major part of the Proterozoic provinces of southwestern United States. This transcontinental collisional event occurred during the Paleoproterozoic (Statherian Period). The Wyoming sector of the Colorado orogeny was formerly called the Medicine Bow orogeny. The eastern sector extends into the High Plains and is called the Central Plains orogeny. The boundary between the Colorado orogeny and the Wyoming craton is the Cheyenne belt, a 5-km-wide mylonitic shear zone that verges northward. The Cheyenne belt transects and cuts off the south edge of the older Trans-Hudson orogeny.""" },
-    { "role": "assistant", "content": """
+Observation: the retrieved wikipedia page summary contains: The Colorado orogeny was an episode of mountain building (an orogeny) in Colorado and surrounding areas.This took place from 1780 to 1650 million years ago (Mya), during the Paleoproterozoic (Statherian Period). It is recorded in the Colorado orogen, a >500-km-wide belt of oceanic arc rock that extends southward into New Mexico. The Colorado orogeny was likely part of the larger Yavapai orogeny."""
+    ),
+    Assistant("""Thought: It does not mention the eastern sector of the Colorado orogeny. I need to look up eastern sector.
+Action: Lookup[eastern sector]"""),
+    User("""Observation: == Description == The Colorado orogen, formerly called the Colorado province, is a >500-km-wide belt of oceanic arc rock (1.78–1.65 Ga) that extends southward into New Mexico and composes a major part of the Proterozoic provinces of southwestern United States. This transcontinental collisional event occurred during the Paleoproterozoic (Statherian Period). The Wyoming sector of the Colorado orogeny was formerly called the Medicine Bow orogeny. The eastern sector extends into the High Plains and is called the Central Plains orogeny. The boundary between the Colorado orogeny and the Wyoming craton is the Cheyenne belt, a 5-km-wide mylonitic shear zone that verges northward. The Cheyenne belt transects and cuts off the south edge of the older Trans-Hudson orogeny."""),
+    Assistant("""
 Thought: The eastern sector of Colorado orogeny extends into the High Plains, so High Plains is the area. I need to search High Plains and find its elevation range.
-Action: Search[High Plains]
-""" },
-    { "role": "user", "content": """
+Action: Search[High Plains]"""),
+    User("""
 Observation: Wikipedia search results for query: 'High Plains' is: 'High Plains', 'High Plains Drifter', 'High Plains (United States)', 'Great Plains', 'Ogallala Aquifer', 'High Plains Invaders', 'High Plains (Australia)', 'High Plains Reader', 'Llano Estacado', 'Bogong High Plains'
 Observation: Title: 'High Plains' is ambiguous. Possible alternatives: High Plains (United States), High Plains (Australia), Altiplano (disambiguation), Western Plains (disambiguation)
 Observation: Retrying with 'High Plains (United States)' (Retry 1/3).
 Observation: Successfully retrieved 'High Plains (United States)' from Wikipedia.
 Observation: the retrieved wikipedia page summary contains: The High Plains are a subregion of the Great Plains, mainly in the Western United States, but also partly in the Midwest states of Nebraska, Kansas, and South Dakota, generally encompassing the western part of the Great Plains before the region reaches the Rocky Mountains.The High Plains are located in eastern Montana, southeastern Wyoming, southwestern South Dakota, western Nebraska, eastern Colorado, western Kansas, eastern New Mexico, the Oklahoma Panhandle, and the Texas Panhandle. The southern region of the Western High Plains ecology region contains the geological formation known as Llano Estacado which can be seen from a short distance or on satellite maps. From east to west, the High Plains rise in elevation from around 1,800 to 7,000 ft (550 to 2,130 m).
-""" },
-    { "role": "assistant", "content": """
+    """),
+    Assistant("""
 Thought: The elevation range of the High Plains is around 1,800 to 7,000 ft (550 to 2,130 m), so that is the answer.
 Action: Finish[1,800 to 7,000 ft]
-""" },
-    { "role": "user", "content": """
-Question: Musician and satirist Allie Goertz wrote a song about the "The Simpsons" character Milhouse, who Matt Groening named after who?
-""" },
-    { "role": "assistant", "content": """
+    """),
+    User("""
+Question: Musician and satirist Allie Goertz wrote a song about the "The Simpsons" character Milhouse, who Matt Groening named after who?"""),
+    Assistant("""
 Thought: The question simplifies to "The Simpsons" character Milhouse is named after who. I only need to search Milhouse and find who it is named after.
-Action: Search[Milhouse]
-""" },
-    { "role": "user", "content": """
+Action: Search[Milhouse]"""
+    ),
+    User("""
 Observation: Wikipedia search results for query: 'Milhouse' is: 'Milhouse Van Houten', 'A Milhouse Divided', 'Pamela Hayden', 'Treehouse of Horror XIX', 'Bart's Friend Falls in Love', 'Milhouse of Sand and Fog', 'Milhouse Doesn't Live Here Anymore', 'Homer Defined', 'List of recurring The Simpsons characters', 'The Simpsons (season 35)'
 Observation: Successfully retrieved 'Milhouse Van Houten' from Wikipedia.
-Observation: the retrieved wikipedia page summary contains: Milhouse Mussolini Van Houten is a recurring character in the Fox animated television series The Simpsons voiced by Pamela Hayden and created by Matt Groening.Milhouse is Bart Simpson's best friend in Mrs. Krabappel's fourth grade class at Springfield Elementary School. He is insecure, gullible, and is often led into trouble by Bart, who takes advantage of his friend's naïveté. Milhouse is a regular target for school bully Nelson Muntz and his friends Jimbo Jones, Dolph Starbeam and Kearney Zzyzwicz. He has an unrequited crush on Bart's sister, Lisa, which is a common plot element. Milhouse debuted in the 1988 commercial "The Butterfinger Group" while The Simpsons was still airing as a cartoon short series on the Fox variety show The Tracey Ullman Show. When The Simpsons was greenlit for a full series by Fox, Milhouse became one of the series' most prominent recurring characters.
-""" },
-    { "role": "assistant", "content": """
+Observation: the retrieved wikipedia page summary contains: Milhouse Mussolini Van Houten is a recurring character in the Fox animated television series The Simpsons voiced by Pamela Hayden and created by Matt Groening.Milhouse is Bart Simpson's best friend in Mrs. Krabappel's fourth grade class at Springfield Elementary School. He is insecure, gullible, and is often led into trouble by Bart, who takes advantage of his friend's naïveté. Milhouse is a regular target for school bully Nelson Muntz and his friends Jimbo Jones, Dolph Starbeam and Kearney Zzyzwicz. He has an unrequited crush on Bart's sister, Lisa, which is a common plot element. Milhouse debuted in the 1988 commercial "The Butterfinger Group" while The Simpsons was still airing as a cartoon short series on the Fox variety show The Tracey Ullman Show. When The Simpsons was greenlit for a full series by Fox, Milhouse became one of the series' most prominent recurring characters."""
+    ),
+    Assistant("""
 Thought: The paragraph does not tell who Milhouse is named after, maybe I can look up "named after".
-Action: Lookup[named after]
-""" },
-    { "role": "user", "content": """
-Observation: Milhouse was named after U.S. president Richard Nixon, whose middle name was Milhous. 
-""" },
-    { "role": "assistant", "content": """
+Action: Lookup[named after]"""
+    ),
+    User("Observation: Milhouse was named after U.S. president Richard Nixon, whose middle name was Milhouse."),
+    Assistant("""
 Thought: Milhouse was named after U.S. president Richard Nixon, so the answer is Richard Nixon.
-Action: Finish[President Richard Nixon]
-""" },
+Action: Finish[President Richard Nixon]"""),
 ]
 
 class TextualReactor:
-    def __init__(self, query_function):
-        self.messages = prompt_messages[:] # clone
+    def __init__(self, query_function, formatter: Formatter):
+        self.prompt = PromptBuilder(prompt_messages)
+        self.formatter = formatter
         self.query_function = query_function
 
     def add_question(self, question: str):
-        self.messages.append({ "role": "user", "content": f"Question: {question}" }) 
+        self.prompt.push(User(f"Question: {question}"))
 
     def add_observation(self, observation, action: Action):
-        self.messages.append({ "role": "user", "content": f"Observation: {observation}" })
+        self.prompt.push(User(f"Observation: {observation}"))
 
     def query(self) -> Action:
-        response = self.query_function(self.messages)
-        self.messages.append(response) # XXX: validate the format of the content?
+        response = self.query_function(self.prompt.build(self.formatter))
+        self.prompt.push(Assistant(response["content"])) # XXX: validate the format of the content?
         print("<<<", response["content"])
         response_lines = response["content"].strip().split('\n')
         last_line = response_lines[-1]


### PR DESCRIPTION
This turned out rather complex (see prompt_builder.py and its inline tests), but it does support every single case we supported so far.

The existing prompts have been converted to the new DSL, catching a few bugs in the process.

The "plaintext" fallback for a generic LLM (without separate messages) can be implemented using `TextualReactor` with `OutputFormat.plain` passed in.